### PR TITLE
Terraform options shouldn't be passed to `get`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,11 @@ ci_build:
 		echo "Tests failed."; \
 		exit 1; \
 	}
-ci_deploy: ADDITIONAL_TERRAFORM_ARGS=-auto-approve -input=false
 ci_deploy: init \
 	_generate_terraform_tfvars \
-	_terraform_init_with_s3_backend \
-	_terraform_apply
+	_terraform_init_with_s3_backend
+ci_deploy: ADDITIONAL_TERRAFORM_ARGS=-auto-approve -input=false
+ci_deploy: _terraform_apply
 
 # Shared build steps.
 .PHONY: stage_environment init


### PR DESCRIPTION
See above! This only fails when deploying from `master`.